### PR TITLE
Propagate errors in the state enter callback up to ProcessRun

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module ergo.services/actor
 
 go 1.20
+
+require ergo.services/ergo v1.999.301-0.20250630075004-8c207f483143 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+ergo.services/ergo v1.999.301-0.20250630075004-8c207f483143 h1:eskmERCSk7Va3A5D/OuX967cJa00t4QjVCKrN4cMsng=
+ergo.services/ergo v1.999.301-0.20250630075004-8c207f483143/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=

--- a/statemachine/go.mod
+++ b/statemachine/go.mod
@@ -2,4 +2,4 @@ module ergo.services/actor/statemachine
 
 go 1.23.4
 
-require ergo.services/ergo v1.999.300
+require ergo.services/ergo v1.999.301-0.20250616192953-f37a173cbea9

--- a/statemachine/go.mod
+++ b/statemachine/go.mod
@@ -2,4 +2,4 @@ module ergo.services/actor/statemachine
 
 go 1.23.4
 
-require ergo.services/ergo v1.999.301-0.20250616192953-f37a173cbea9
+require ergo.services/ergo v1.999.301-0.20250630075004-8c207f483143

--- a/statemachine/go.sum
+++ b/statemachine/go.sum
@@ -1,2 +1,4 @@
 ergo.services/ergo v1.999.300 h1:bc24HqjaObObkagVknG42uIqbYEXxECRlrHWIR4PnPI=
 ergo.services/ergo v1.999.300/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=
+ergo.services/ergo v1.999.301-0.20250616192953-f37a173cbea9 h1:jpTi0Xe7gPvq3oG0EhxCpBr7jbCFMtk7eO9z5CZ9drg=
+ergo.services/ergo v1.999.301-0.20250616192953-f37a173cbea9/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=

--- a/statemachine/go.sum
+++ b/statemachine/go.sum
@@ -2,3 +2,5 @@ ergo.services/ergo v1.999.300 h1:bc24HqjaObObkagVknG42uIqbYEXxECRlrHWIR4PnPI=
 ergo.services/ergo v1.999.300/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=
 ergo.services/ergo v1.999.301-0.20250616192953-f37a173cbea9 h1:jpTi0Xe7gPvq3oG0EhxCpBr7jbCFMtk7eO9z5CZ9drg=
 ergo.services/ergo v1.999.301-0.20250616192953-f37a173cbea9/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=
+ergo.services/ergo v1.999.301-0.20250630075004-8c207f483143 h1:eskmERCSk7Va3A5D/OuX967cJa00t4QjVCKrN4cMsng=
+ergo.services/ergo v1.999.301-0.20250630075004-8c207f483143/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -29,7 +29,7 @@ type StateMachineBehavior[D any] interface {
 
 	CurrentState() gen.Atom
 
-	SetCurrentState(gen.Atom)
+	SetCurrentState(gen.Atom) error
 
 	Data() D
 
@@ -218,7 +218,7 @@ func (s *StateMachine[D]) CurrentState() gen.Atom {
 	return s.currentState
 }
 
-func (s *StateMachine[D]) SetCurrentState(state gen.Atom) {
+func (s *StateMachine[D]) SetCurrentState(state gen.Atom) error {
 	if state != s.currentState {
 		s.Log().Info("StateMachine: switching to state %s", state)
 		oldState := s.currentState
@@ -236,12 +236,13 @@ func (s *StateMachine[D]) SetCurrentState(state gen.Atom) {
 		if s.stateEnterCallback != nil {
 			newState, newData, err := s.stateEnterCallback(oldState, state, s.data, s)
 			if err != nil {
-				panic(fmt.Sprintf("error in StateEnterCallback for state %s", state))
+				return err
 			}
 			s.SetData(newData)
 			s.SetCurrentState(newState)
 		}
 	}
+	return nil
 }
 
 func (s *StateMachine[D]) Data() D {
@@ -600,9 +601,8 @@ func (s *StateMachine[D]) invokeMessageHandler(handler any, message *gen.Mailbox
 	if isError, err := resultIsError(results); isError == true {
 		return err
 	}
-	updateStateMachineWithResults(stateMachineValue, results)
 
-	return nil
+	return updateStateMachineWithResults(stateMachineValue, results)
 }
 
 func (s *StateMachine[D]) lookupCallHandler(messageType string) (any, bool) {
@@ -669,7 +669,7 @@ func resultIsError(results []reflect.Value) (bool, error) {
 	return false, nil
 }
 
-func updateStateMachineWithResults(s reflect.Value, results []reflect.Value) {
+func updateStateMachineWithResults(s reflect.Value, results []reflect.Value) error {
 	// Check if any actions were returned. MessageHandler and EventHandler have
 	// the result tuple (gen.Atom, D, []Action, error) with the actions at index
 	// 2. CallHandler has the result typle (gen.Atom, D, R, []Action, error)
@@ -698,7 +698,12 @@ func updateStateMachineWithResults(s reflect.Value, results []reflect.Value) {
 	// they are defined for. A state enter callback could transition to another
 	// state which then will cancel the state timeout.
 	setCurrentStateMethod := s.MethodByName("SetCurrentState")
-	setCurrentStateMethod.Call([]reflect.Value{results[0]})
+	err := setCurrentStateMethod.Call([]reflect.Value{results[0]})[0]
+	if !err.IsNil() {
+		return err.Interface().(error)
+	}
+
+	return nil
 }
 
 func isSliceNilOrEmpty(resultValue reflect.Value) bool {

--- a/statemachine/statemachine.go
+++ b/statemachine/statemachine.go
@@ -628,9 +628,11 @@ func (s *StateMachine[D]) invokeCallHandler(handler any, message *gen.MailboxMes
 	if isError, err := resultIsError(results); isError == true {
 		return nil, err
 	}
-	updateStateMachineWithResults(stateMachineValue, results)
+	err := updateStateMachineWithResults(stateMachineValue, results)
+	if err != nil {
+		return nil, err
+	}
 	result := results[2].Interface()
-
 	return result, nil
 }
 

--- a/statemachine/statemachine_test.go
+++ b/statemachine/statemachine_test.go
@@ -1,0 +1,71 @@
+package statemachine
+
+import (
+	"testing"
+
+	"ergo.services/ergo/gen"
+	"ergo.services/ergo/testing/unit"
+)
+
+type Data struct{}
+
+type BasicStatemachine struct {
+	StateMachine[Data]
+}
+
+type StateChange struct{}
+
+func factoryBasicStatemachine() gen.ProcessBehavior {
+	return &BasicStatemachine{}
+}
+
+func (b *BasicStatemachine) Init(args ...any) (StateMachineSpec[Data], error) {
+	spec := NewStateMachineSpec(
+		gen.Atom("StateA"),
+
+		WithStateEnterCallback(stateEnter),
+		WithStateMessageHandler(gen.Atom("StateA"), changeState),
+		WithStateCallHandler(gen.Atom("StateA"), changeStateSync),
+	)
+	return spec, nil
+}
+
+func changeState(state gen.Atom, data Data, msg StateChange, proc gen.Process) (gen.Atom, Data, []Action, error) {
+	return gen.Atom("StateB"), data, nil, nil
+}
+
+func changeStateSync(state gen.Atom, data Data, msg StateChange, proc gen.Process) (gen.Atom, Data, gen.Atom, []Action, error) {
+	return gen.Atom("StateB"), data, gen.Atom("StateB"), nil, nil
+}
+
+func stateEnter(oldState gen.Atom, newState gen.Atom, data Data, proc gen.Process) (gen.Atom, Data, error) {
+	if newState == gen.Atom("StateB") {
+		return newState, data, gen.TerminateReasonNormal
+	}
+	return newState, data, nil
+}
+
+func TestStateEnterCallback_SendShouldPropagateErrors(t *testing.T) {
+	actor, err := unit.Spawn(t, factoryBasicStatemachine)
+	unit.Nil(t, err)
+
+	actor.SendMessage(
+		gen.PID{Node: "test", ID: 100, Creation: 0},
+		StateChange{})
+
+	unit.Equal(t, true, actor.IsTerminated())
+	unit.Equal(t, gen.TerminateReasonNormal, actor.TerminationReason())
+}
+
+func TestStateEnterCallback_CallShouldPropagateErrors(t *testing.T) {
+	actor, err := unit.Spawn(t, factoryBasicStatemachine)
+	unit.Nil(t, err)
+
+	res := actor.Call(
+		gen.PID{Node: "test", ID: 100, Creation: 0},
+		StateChange{})
+
+	unit.Equal(t, gen.TerminateReasonNormal, res.Error)
+	unit.Equal(t, true, actor.IsTerminated())
+	unit.Equal(t, gen.TerminateReasonNormal, actor.TerminationReason())
+}


### PR DESCRIPTION
We shouldn't panic if the state enter callback returns an error. Instead, those errors should be propagated to `ProcessRun` to allow for terminating the actor from the callback. 

PS: I have added a single test here using the new unit framework. Over time, I will rewrite the existing tests and start adding them here as well.