### PR TITLE
fix: use SendAfter for timeout handling (Ergo v3.2.0 compatibility)

### DIFF
--- a/statemachine/go.mod
+++ b/statemachine/go.mod
@@ -2,4 +2,4 @@ module ergo.services/actor/statemachine
 
 go 1.23.4
 
-require ergo.services/ergo v1.999.301-0.20250630075004-8c207f483143
+require ergo.services/ergo v1.999.320

--- a/statemachine/go.sum
+++ b/statemachine/go.sum
@@ -1,2 +1,2 @@
-ergo.services/ergo v1.999.301-0.20250630075004-8c207f483143 h1:eskmERCSk7Va3A5D/OuX967cJa00t4QjVCKrN4cMsng=
-ergo.services/ergo v1.999.301-0.20250630075004-8c207f483143/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=
+ergo.services/ergo v1.999.320 h1:IYyjCBJvXPLW8Mpy6pq5FoBa2RjNAS4QSL2lK7bBueQ=
+ergo.services/ergo v1.999.320/go.mod h1:bLQ6PoO6Mz/8gVuzvPv3xfMfo1P9w6rZV1WnMXMeMdg=


### PR DESCRIPTION
Ergo v3.2.0 changed process.SendPID() to reject calls when the process is in Sleep state. The timeout mechanism previously used goroutines that called proc.Send() which fails silently in this case.

Changed to use proc.SendAfter() which uses node-level routing that bypasses the process state check.